### PR TITLE
Auto-assign devops team members as reviewers in PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "docker": {
     "enabled": false
   },
+  "reviewers": ["team:devops"],
   "terraform": {
     "depTypes": ["helm_release"]
   },


### PR DESCRIPTION
Have renovate automatically assign the adorsys org team [devops](https://github.com/orgs/adorsys/teams/devops) as reviewer for its pull requests.