### PR TITLE
Auto-assign devops team members as reviewers in PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "terraform": {
     "depTypes": ["helm_release"]
   },
+  "reviewers": ["team:devops"],
   "groupName": "all",
   "timezone": "Europe/Berlin",
   "schedule": [


### PR DESCRIPTION
Have renovate automatically assign the adorsys org team devops as reviewer for its pull requests.