### PR TITLE
Fix assigned reviewers for renovate PR's

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,6 @@
   "terraform": {
     "depTypes": ["helm_release"]
   },
-  "reviewers": ["team:devops"],
   "groupName": "all",
   "timezone": "Europe/Berlin",
   "schedule": [
@@ -31,7 +30,7 @@
     },
     {
       "matchUpdateTypes": ["major", "minor"],
-      "reviewers": ["devops"]
+      "reviewers": ["team:devops"]
     }
   ]
 }


### PR DESCRIPTION
@adorsys/devops doesn't get assigned as reviewers for major and minor updates because of wrong configuration of the `reviewers` option.
This fixes this issue